### PR TITLE
Add Yandex Mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Currently supported apps:
 - Outlook
 - Yahoo Mail
 - Superhuman
+- Yandex
 
 ## Installation
 
@@ -48,6 +49,7 @@ Just add this in your `Info.plist` depending on which apps you'd like to support
     <string>inbox-gmail</string>
     <string>ymail</string>
     <string>superhuman</string>
+    <string>yandexmail</string>
 </array>
 ```
 

--- a/docs/expo.md
+++ b/docs/expo.md
@@ -19,7 +19,8 @@ Simply add the following to your Expo app's `app.json` file:
          "googlegmail",
          "inbox-gmail",
          "ymail",
-         "superhuman"
+         "superhuman",
+         "yandexmail"
       ]
    }
 }

--- a/src/ios.js
+++ b/src/ios.js
@@ -10,6 +10,7 @@ const prefixes = {
   outlook: "ms-outlook://",
   yahoo: "ymail://",
   superhuman: "superhuman://",
+  yandex: "yandexmail://",
 };
 
 const titles = {
@@ -21,6 +22,7 @@ const titles = {
   outlook: "Outlook",
   yahoo: "Yahoo Mail",
   superhuman: "Superhuman",
+  yandex: "Yandex",
 };
 
 /**
@@ -95,6 +97,9 @@ const uriParams = {
     subject: "subject",
     body: "body",
   },
+  yandex: {
+    path: "compose",
+  }
 };
 
 /**


### PR DESCRIPTION
Yandex Mail is one of the most popular email clients in Russia. It would be nice if this library also supports this client.

The URL scheme: `yandexmail://`
The path to compose a new email: `compose`

It seems that the additional parameters (to, cc, bcc, subject, body) are not supported yet by this app.