### PR TITLE
Add placeholder index.js file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+// Placeholder file so that Expo plugin module resolution works


### PR DESCRIPTION
So that the Expo plugin module resolution works. Fixes #96

After a lot of investigation the reason that the Expo plugin module resolution fails is because it can't find a `index.js` file. The module resolution happens in node so it doesn't pick up the `.ios.js` or `.android.js` files.