### PR TITLE
Feature/android no mail apps error

### DIFF
--- a/android/src/main/java/agency/flexible/react/modules/email/EmailModule.java
+++ b/android/src/main/java/agency/flexible/react/modules/email/EmailModule.java
@@ -64,7 +64,7 @@ public class EmailModule extends ReactContextBaseJavaModule {
 
             promise.resolve(true);
         } else {
-            promise.reject("EmailException", "No email apps available");
+            promise.reject("NoEmailAppsAvailable", "No email apps available");
         }
     }
 

--- a/android/src/main/java/agency/flexible/react/modules/email/EmailModule.java
+++ b/android/src/main/java/agency/flexible/react/modules/email/EmailModule.java
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -27,7 +28,7 @@ public class EmailModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void open(final String title, final boolean newTask) {
+    public void open(final String title, final boolean newTask, final Promise promise) {
         Intent emailIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("mailto:"));
         PackageManager pm = getCurrentActivity().getPackageManager();
 
@@ -60,6 +61,10 @@ public class EmailModule extends ReactContextBaseJavaModule {
                 setNewTaskFlag(openInChooser, newTask);
                 getCurrentActivity().startActivity(openInChooser);
             }
+
+            promise.resolve(true);
+        } else {
+            promise.reject("EmailException", "No email apps available");
         }
     }
 

--- a/src/android.js
+++ b/src/android.js
@@ -28,7 +28,13 @@ export async function openInbox(options = {}) {
     newTask = Boolean(options.newTask);
   }
 
-  return NativeModules.Email.open(text, newTask);
+  try {
+    await NativeModules.Email.open(text, newTask);
+  } catch (error) {
+    if (error.code === "NoEmailAppsAvailable") {
+      throw new EmailException("No email apps available");
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Throw an error from Android native `open` method in the case where no email apps are found. Catch this error in the JS side, and throw the error using the custom `EmailException` with the same message that is used on iOS for the same situation.

Fixes https://github.com/flexible-agency/react-native-email-link/issues/104

